### PR TITLE
Добавлен .DS_Store в .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Добавила файл .DS_Store в файл .gitignore, чтобы Git игнорировал этот файл в репозитории. Это нужно, чтобы избежать добавления системных файлов macOS в репозиторий.